### PR TITLE
Empty restaurant name search and tests

### DIFF
--- a/backend test/testrestaurant.js
+++ b/backend test/testrestaurant.js
@@ -8,7 +8,6 @@ var request = require('request');
 var should = require('should');
 
 describe('Search By Tag Router test',function(){
-
     it('should return a list of restaurants which contain breakfast menus, are located in gainesville and are sorted rating wise in descending order', function() {
         var tag = "breakfast";
         var city = "gainesville";
@@ -35,7 +34,7 @@ describe('Search By Tag Router test',function(){
                     expect(rating).to.not.be.above(prevRating);
                     prevRating = rating;
                 }
-
+            
               });
               done();
     });
@@ -294,7 +293,6 @@ describe('Search Router test',function(){
             });
               done();
     });
-
 });  
 
 describe('Search by Location Router test',function(){

--- a/backend test/testrestaurant.js
+++ b/backend test/testrestaurant.js
@@ -274,6 +274,27 @@ describe('Search Router test',function(){
               done();
     });
 
+    it('should return all restaurants in gainesville sorted in descending order rating wise when the restaurant name search box is empty', function() {
+        var city = "gainesville";
+        return chai
+            .request('http://localhost:3000/restaurants')
+            .post('/search')
+            .send( {
+                "city":city,
+            })
+            .then(function(res) {
+                var i;
+                var prevRating = 1000;
+                for(i = 0; i < res.body.length; i = i + 1){
+                    expect(res.body[i]._source.city).to.equal(city);
+                    var rating = parseFloat(res.body[i]._source.rating)
+                    expect(rating).to.not.be.above(prevRating);
+                    prevRating = rating;   
+                }
+            });
+              done();
+    });
+
 });  
 
 describe('Search by Location Router test',function(){
@@ -313,6 +334,27 @@ describe('Search by Location Router test',function(){
                 }
 
               });
+              done();
+    });
+
+    it('should return all restaurants within 25km of geo-location sorted in descending order rating wise when the restaurant name search box is empty', function() {
+        var location = "29.617976, -82.383637";
+        return chai
+            .request('http://localhost:3000/restaurants')
+            .post('/searchByLocation')
+            .send( {
+                "location":location,
+            })
+            .then(function(res) {
+                var i;
+                var prevRating = 1000;
+                for(i = 0; i < res.body.length; i = i + 1){
+                    expect(calculateDistance(res.body[i]._source.location,location)).to.not.be.above(25);
+                    var rating = parseFloat(res.body[i]._source.rating)
+                    expect(rating).to.not.be.above(prevRating);
+                    prevRating = rating;   
+                }
+            });
               done();
     });
 });

--- a/backend test/testrestaurant.js
+++ b/backend test/testrestaurant.js
@@ -71,6 +71,99 @@ describe('Search By Tag Router test',function(){
               done();
     });
 
+    it('should return a list of restaurants which contain dinner menus, are located in gainesville and are sorted rating wise in descending order', function() {
+        var tag = "dinner";
+        var city = "gainesville";
+        return chai
+            .request('http://localhost:3000/restaurants')
+            .post('/searchByTag')
+            .send( {
+                "tag":tag,
+                "city":city,
+            })
+            .then(function(res) {
+                var i;
+                var prevRating = 1000;
+                for(i = 0; i < res.body.length; i = i + 1){
+                    expect(res.body[i]._source.city).to.equal(city);
+                    var j;
+                    var status = false;
+                    for(j = 0; j < res.body[i]._source.tags.length; j++){
+                        if(res.body[i]._source.tags[j] == tag)
+                            status = true;
+                    }
+                    expect(status).to.equal(true);
+                    var rating = parseFloat(res.body[i]._source.rating)
+                    expect(rating).to.not.be.above(prevRating);
+                    prevRating = rating;
+                }
+
+              });
+              done();
+    });
+
+    it('should return a list of restaurants which have delivery service, are located in gainesville and are sorted rating wise in descending order', function() {
+        var tag = "delivery";
+        var city = "gainesville";
+        return chai
+            .request('http://localhost:3000/restaurants')
+            .post('/searchByTag')
+            .send( {
+                "tag":tag,
+                "city":city,
+            })
+            .then(function(res) {
+                var i;
+                var prevRating = 1000;
+                for(i = 0; i < res.body.length; i = i + 1){
+                    expect(res.body[i]._source.city).to.equal(city);
+                    var j;
+                    var status = false;
+                    for(j = 0; j < res.body[i]._source.tags.length; j++){
+                        if(res.body[i]._source.tags[j] == tag)
+                            status = true;
+                    }
+                    expect(status).to.equal(true);
+                    var rating = parseFloat(res.body[i]._source.rating)
+                    expect(rating).to.not.be.above(prevRating);
+                    prevRating = rating;
+                }
+
+              });
+              done();
+    });
+
+    it('should return a list of restaurants which have take out option, are located in orlando and are sorted rating wise in descending order', function() {
+        var tag = "take out";
+        var city = "orlando";
+        return chai
+            .request('http://localhost:3000/restaurants')
+            .post('/searchByTag')
+            .send( {
+                "tag":tag,
+                "city":city,
+            })
+            .then(function(res) {
+                var i;
+                var prevRating = 1000;
+                for(i = 0; i < res.body.length; i = i + 1){
+                    expect(res.body[i]._source.city).to.equal(city);
+                    var j;
+                    var status = false;
+                    for(j = 0; j < res.body[i]._source.tags.length; j++){
+                        if(res.body[i]._source.tags[j] == tag)
+                            status = true;
+                    }
+                    expect(status).to.equal(true);
+                    var rating = parseFloat(res.body[i]._source.rating)
+                    expect(rating).to.not.be.above(prevRating);
+                    prevRating = rating;
+                }
+
+              });
+              done();
+    });
+
     it('should return a list of restaurants which have "nightlife" tag,are located in gainesville and are sorted rating wise in descending order', function() {
         var tag = "nightlife";
         var city = "gainesville";

--- a/routes/restaurants.js
+++ b/routes/restaurants.js
@@ -88,9 +88,31 @@ searchRouter.route('/')
         };
         search(searchByCityQuery, {}, res);
     }
+    else if( req.body.hasOwnProperty("city")) {
+        var city = req.body.city;
+    
+        var searchByCityQuery = {
+            "query": {
+                "bool": {
+                    "must": [{
+                        "term": {
+                            "city": city
+                        }
+                    }
+                    ]
+                }
+            },
+            "sort": {
+                "rating": {
+                    "order": "desc"
+                }
+            }
+        };
+        search(searchByCityQuery, {}, res);
+    }
     else {
         res.status(400);
-        res.json({ error: "Expected variables not found. Expected variables : search, city" });
+        res.json({ error: "Expected variables not found. Expected variables : city" });
     }
 });
 
@@ -136,6 +158,41 @@ searchByLocationRouter.route('/')
             }
         };
         search(searchByLocationQuery, { "lat": lat, "lon": lon }, res);
+    }
+    else if( req.body.hasOwnProperty("location")) {
+        
+        var location = req.body.location;
+        try {
+            var ss = location.split(",");
+            var lat = parseFloat(ss[0]);
+            var lon = parseFloat(ss[1]);
+        }
+        catch (err) {
+            return res.send('400', { error: 'Location field not of expected type. Expected : /"number, number/"' });
+        }
+    
+        var searchByCityQuery = {
+            "query": {
+                "match_all": {},
+                "bool": {
+                    "filter": {
+                        "geo_distance": {
+                            "distance": "20km",
+                            "location": {
+                                "lat": lat,
+                                "lon": lon
+                            }
+                        }
+                    }
+                }
+            },
+            "sort": {
+                "rating": {
+                    "order": "desc"
+                }
+            }
+        };
+        search(searchByCityQuery, {}, res);
     }
     else {
         res.status(400);

--- a/routes/restaurants.js
+++ b/routes/restaurants.js
@@ -171,9 +171,8 @@ searchByLocationRouter.route('/')
             return res.send('400', { error: 'Location field not of expected type. Expected : /"number, number/"' });
         }
     
-        var searchByCityQuery = {
+        var searchByLocationQuery = {
             "query": {
-                "match_all": {},
                 "bool": {
                     "filter": {
                         "geo_distance": {
@@ -192,7 +191,7 @@ searchByLocationRouter.route('/')
                 }
             }
         };
-        search(searchByCityQuery, {}, res);
+        search(searchByLocationQuery, {}, res);
     }
     else {
         res.status(400);


### PR DESCRIPTION
Following 2 functinoalities were added:
1)Added the functionality to return all the restaurants in the user specified city sorted in descending order rating wise when the restaurant name search box is empty.
2)Added the functionality to return all the restaurants within 25km of user's geo-location sorted in descending order rating wise when the restaurant name search box is empty.

3)Added tests for above 2 functionalities.
4)Added tests for all the tags of search by tag router.

